### PR TITLE
Support %deviceId% as placeholder for MQTT topic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ following parts:
 * Topic Prefix – The start of each topic
 * Topic – Per publication defined topic
 
-In each of these you can use `%deviceName%` and `%roomName%` as variables.
-For example having `Foo/bar` as prefix and `%roomName%/%deviceName%` as 
-topic can result in a message published on the topic 
-`Foo/bar/livingRoom/dimmer`. Both `%deviceName%` and `%roomName%` will be
-camelcased.
+In each of these you can use `%deviceId%`, `%deviceName%` and `%roomName%`
+as variables. For example having `Foo/bar` as prefix and
+`%roomName%/%deviceName%` as topic can result in a message published on the
+topic `Foo/bar/livingRoom/dimmer`. Both `%deviceName%` and `%roomName%` will
+be camelcased.
 
 ## Interacting through MQTT
 
@@ -66,9 +66,9 @@ the two postfixes are used:
 * Status postfix (default: status)
 * Set postfix (default: set)
 
-Taking the same example as before, when you publish an empty message to 
+Taking the same example as before, when you publish an empty message to
 `Foo/bar/livingRoom/dimmer/status` the current value will be published
-again. When you publish a value (for example `on`, `off` or `87`) to 
+again. When you publish a value (for example `on`, `off` or `87`) to
 `Foo/bar/livingRoom/dimmer/set` the dimmer will be set to that level.
 
 # Acknowledgements

--- a/index.js
+++ b/index.js
@@ -284,7 +284,8 @@ MQTT.prototype.createTopic = function (pattern, device) {
 	if (device != undefined) {
 		topicParts = topicParts.map(function (part) {
 			return part.replace("%roomName%", self.findRoom(device.get("location")).title.toCamelCase())
-					   .replace("%deviceName%", device.get("metrics:title").toCamelCase());
+					   .replace("%deviceName%", device.get("metrics:title").toCamelCase())
+             .replace("%deviceId%", device.id.toString(16));
 
 			return part;
 		});

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,6 @@
 	"tags_label": "Tags",
 	"tags_helper": "All devices with this tag will be used",
 	"topic_label": "Topic",
-	"topic_helper": "You can use %deviceName% and %roomName% to get those automatically filled in. The names will camel cased.",
+	"topic_helper": "You can use %deviceId%, %deviceName% and %roomName% to get those automatically filled in. The names will camel cased.",
 	"retained_label": "Retained?"
 }


### PR DESCRIPTION
This PR is adding the possibility to use the placeholder `%deviceId%` for the MQTT topic names. So it's technically easier to use the topics to use other processes / systems to work with the incoming data.

It would be great if this could be merged into the core project.