### PR TITLE
Adding support for syncing „all“ devices with one publication

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,6 +250,9 @@ MQTT.prototype.processPublicationsForDevice = function (device, callback) {
 
 	_.each(self.config.publications, function (publication) {
 		switch (publication.type) {
+  		case "all":
+				callback(device, publication);
+  			break;
 			case "tag":
 				if (_.intersection(publication.tags, device.get("tags")).length > 0) {
 					callback(device, publication);

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,6 +24,7 @@
 
 	"type_label": "Type",
 	"type_choose": "Choose the type of publication",
+	"type_all": "All devices",
 	"type_single": "Single device",
 	"type_tag": "Tagged devices",
 

--- a/module.json
+++ b/module.json
@@ -13,7 +13,10 @@
 		"topicPrefix": "zway",
 		"topicPostfixStatus": "status",
 		"topicPostfixSet": "set",
-		"ignore": true
+		"ignore": true,
+    "publications": [
+      { "type": "all", "topic": "%deviceId%" }
+    ]
 	},
 	"dependencies": [
 		"BaseModule"
@@ -86,6 +89,7 @@
 							"label" : "__type_label__",
 							"noneLabel" : "__type_choose__",
 							"optionLabels" : [
+								"__type_all__",
 								"__type_tag__",
 								"__type_single__"
 							],
@@ -183,6 +187,7 @@
 						"type" : {
 							"type" : "string",
 							"enum" : [
+                "all",
 								"tag",
 								"single"
 							],


### PR DESCRIPTION
This pull requests adds the option to sync all devices with one publication option, which makes the setup on our end a lot easier. 

<img width="1166" src="https://user-images.githubusercontent.com/36688/72521640-1a714900-385c-11ea-8504-ca5b3797b9b2.png">

We also set this option as a default publication, so the initial setup is directly working without any specific publication. In combination with the %deviceId% placeholder, this gives us the flexibility we needed.

Would be great to see this merged and the plugin updated. As for now, we roll this out manually.